### PR TITLE
use stub to generate arginfo

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -47,6 +47,9 @@
             <file name="config.w32" role="src"/>
             <file name="php_uploadprogress.h" role="src"/>
             <file name="uploadprogress.c" role="src"/>
+            <file name="uploadprogress.stub.php" role="src"/>
+            <file name="uploadprogress_arginfo.h" role="src"/>
+            <file name="uploadprogress_legacy_arginfo.h" role="src"/>
             <file name="LICENSE" role="doc"/>
             <file name="README.md" role="doc"/>
             <dir name="examples">

--- a/uploadprogress.c
+++ b/uploadprogress.c
@@ -30,34 +30,11 @@
 #endif
 
 /* {{{ argument information */
-#if PHP_API_VERSION >= 20200930
-ZEND_BEGIN_ARG_INFO_EX(arginfo_uploadprogress_get_info, 0, 0, 1)
-    ZEND_ARG_TYPE_INFO(0, identifier, IS_STRING, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_uploadprogress_get_contents, 0, 0, 2)
-    ZEND_ARG_TYPE_INFO(0, identifier, IS_STRING, 0)
-    ZEND_ARG_TYPE_INFO(0, fieldname, IS_STRING, 0)
-    ZEND_ARG_TYPE_INFO(0, maxlen, IS_LONG, 1)
-ZEND_END_ARG_INFO()
-#endif
-/* }}} */
-
-/* {{{ uploadprogress_functions[] */
-#if PHP_API_VERSION >= 20200930
-zend_function_entry uploadprogress_functions[] = {
-    PHP_FE(uploadprogress_get_info, arginfo_uploadprogress_get_info)
-    PHP_FE(uploadprogress_get_contents, arginfo_uploadprogress_get_contents)
-    { NULL, NULL, NULL }
-};
+#if PHP_VERSION_ID < 80000
+#include "uploadprogress_legacy_arginfo.h"
 #else
-zend_function_entry uploadprogress_functions[] = {
-    PHP_FE(uploadprogress_get_info, NULL)
-    PHP_FE(uploadprogress_get_contents, NULL)
-    { NULL, NULL, NULL }
-};
+#include "uploadprogress_arginfo.h"
 #endif
-/* }}} */
 
 PHP_INI_BEGIN()
 PHP_INI_ENTRY("uploadprogress.file.filename_template", TMPDIR"/upt_%s.txt",         PHP_INI_ALL, NULL)
@@ -70,7 +47,7 @@ PHP_INI_END()
 zend_module_entry uploadprogress_module_entry = {
     STANDARD_MODULE_HEADER,
     "uploadprogress",
-    uploadprogress_functions,
+    ext_functions,
     PHP_MINIT(uploadprogress),
     PHP_MSHUTDOWN(uploadprogress),
     PHP_RINIT(uploadprogress),

--- a/uploadprogress.stub.php
+++ b/uploadprogress.stub.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * @generate-function-entries
+ * @generate-legacy-arginfo
+ */
+
+function uploadprogress_get_info(string $identifier): ?array {};
+
+function uploadprogress_get_contents(string $identifier, string $fieldname, int $maxlen=PHP_STREAM_COPY_ALL): ?string {};
+

--- a/uploadprogress.stub.php
+++ b/uploadprogress.stub.php
@@ -7,5 +7,5 @@
 
 function uploadprogress_get_info(string $identifier): ?array {};
 
-function uploadprogress_get_contents(string $identifier, string $fieldname, int $maxlen=PHP_STREAM_COPY_ALL): ?string {};
+function uploadprogress_get_contents(string $identifier, string $fieldname, int $maxlen=-1): ?string {};
 

--- a/uploadprogress_arginfo.h
+++ b/uploadprogress_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 5f78bc7f8b12cfd54c838e6e6e85b9f28b67b386 */
+ * Stub hash: 2d041ae6d6a3d972168fe0cc71978048f694a39c */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_uploadprogress_get_info, 0, 1, IS_ARRAY, 1)
 	ZEND_ARG_TYPE_INFO(0, identifier, IS_STRING, 0)

--- a/uploadprogress_arginfo.h
+++ b/uploadprogress_arginfo.h
@@ -1,0 +1,23 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 5f78bc7f8b12cfd54c838e6e6e85b9f28b67b386 */
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_uploadprogress_get_info, 0, 1, IS_ARRAY, 1)
+	ZEND_ARG_TYPE_INFO(0, identifier, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_uploadprogress_get_contents, 0, 2, IS_STRING, 1)
+	ZEND_ARG_TYPE_INFO(0, identifier, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, fieldname, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, maxlen, IS_LONG, 0, "-1")
+ZEND_END_ARG_INFO()
+
+
+ZEND_FUNCTION(uploadprogress_get_info);
+ZEND_FUNCTION(uploadprogress_get_contents);
+
+
+static const zend_function_entry ext_functions[] = {
+	ZEND_FE(uploadprogress_get_info, arginfo_uploadprogress_get_info)
+	ZEND_FE(uploadprogress_get_contents, arginfo_uploadprogress_get_contents)
+	ZEND_FE_END
+};

--- a/uploadprogress_legacy_arginfo.h
+++ b/uploadprogress_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 5f78bc7f8b12cfd54c838e6e6e85b9f28b67b386 */
+ * Stub hash: 2d041ae6d6a3d972168fe0cc71978048f694a39c */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_uploadprogress_get_info, 0, 0, 1)
 	ZEND_ARG_INFO(0, identifier)

--- a/uploadprogress_legacy_arginfo.h
+++ b/uploadprogress_legacy_arginfo.h
@@ -1,0 +1,23 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 5f78bc7f8b12cfd54c838e6e6e85b9f28b67b386 */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_uploadprogress_get_info, 0, 0, 1)
+	ZEND_ARG_INFO(0, identifier)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_uploadprogress_get_contents, 0, 0, 2)
+	ZEND_ARG_INFO(0, identifier)
+	ZEND_ARG_INFO(0, fieldname)
+	ZEND_ARG_INFO(0, maxlen)
+ZEND_END_ARG_INFO()
+
+
+ZEND_FUNCTION(uploadprogress_get_info);
+ZEND_FUNCTION(uploadprogress_get_contents);
+
+
+static const zend_function_entry ext_functions[] = {
+	ZEND_FE(uploadprogress_get_info, arginfo_uploadprogress_get_info)
+	ZEND_FE(uploadprogress_get_contents, arginfo_uploadprogress_get_contents)
+	ZEND_FE_END
+};


### PR DESCRIPTION
This also add arginfo for 7.x but without type hitting

This add return type hinting for 8.x

I don't think this is can be seen as a BC break... btw 2.0.x is a new major version

Also fix `$maxlen` which is optional, but cannot be null (not accepted in zend_parse_parameters)

Diff of reflection output (8.x)

```
@@ -14,19 +14,21 @@
 
   - Functions {
     Function [ <internal:uploadprogress> function uploadprogress_get_info ] {
 
       - Parameters [1] {
         Parameter #0 [ <required> string $identifier ]
       }
+      - Return [ ?array ]
     }
     Function [ <internal:uploadprogress> function uploadprogress_get_contents ] {
 
       - Parameters [3] {
         Parameter #0 [ <required> string $identifier ]
         Parameter #1 [ <required> string $fieldname ]
-        Parameter #2 [ <optional> ?int $maxlen = <default> ]
+        Parameter #2 [ <optional> int $maxlen = -1 ]
       }
+      - Return [ ?string ]
     }
   }
 }

```

Diff of reflection output (7.x)

```
@@ -14,8 +14,18 @@
 
   - Functions {
     Function [ <internal:uploadprogress> function uploadprogress_get_info ] {
+
+      - Parameters [1] {
+        Parameter #0 [ <required> $identifier ]
+      }
     }
     Function [ <internal:uploadprogress> function uploadprogress_get_contents ] {
+
+      - Parameters [3] {
+        Parameter #0 [ <required> $identifier ]
+        Parameter #1 [ <required> $fieldname ]
+        Parameter #2 [ <optional> $maxlen ]
+      }
     }
   }
 }

```